### PR TITLE
Add render with options

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,11 +5,11 @@ version: 0.2.0
 authors:
   - Tatsiujin Chin <c910335@gmail.com>
 
-crystal: 0.31.1
+crystal: 0.34.0
 
 license: MIT
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.10.1
+    version: ~> 0.12.1

--- a/spec/crinder_spec.cr
+++ b/spec/crinder_spec.cr
@@ -6,9 +6,11 @@ class TimeRenderer < Crinder::Base(Time?)
   field year : Int
   field month : Int
   field day : Int
-  field hour : Int
-  field minute : Int
-  field second : Int
+  field hour : Int, unless: date_only?
+  field minute : Int, unless: date_only?
+  field second : Int, unless: date_only?
+
+  option date_only? : Bool = false
 end
 
 class TodoRenderer < Crinder::Base(Todo)
@@ -45,6 +47,7 @@ class NestedTodoRenderer < TodoRenderer
   remove expires_at
   remove updated
   field created_at, with: TimeRenderer
+  field updated_at, with: TimeRenderer, options: {date_only?: true}
 end
 
 class NilableTodoRenderer < TodoRenderer
@@ -111,7 +114,7 @@ describe Crinder::Base do
         time = Time.utc(2018, 3, 14, 18, 49, 59)
         t = Todo.new("WTF", 6, time, time, time)
 
-        NestedTodoRenderer.render(t).should eq(%{{"title":"WTF","priority":60,"created_at":{"year":2018,"month":3,"day":14,"hour":18,"minute":49,"second":59}}})
+        NestedTodoRenderer.render(t).should eq(%{{"title":"WTF","priority":60,"created_at":{"year":2018,"month":3,"day":14,"hour":18,"minute":49,"second":59},"updated_at":{"year":2018,"month":3,"day":14}}})
       end
     end
 

--- a/src/crinder.cr
+++ b/src/crinder.cr
@@ -112,7 +112,11 @@ class Crinder::Base(T)
               %field = "{{(options[:as] || name).id}}"
               {% if render_with = options[:with] %}
                 json.field %field do
-                  {{render_with}}.render(__value_of({{name}}), json)
+                  {% if render_options = options[:options] %}
+                    {{render_with}}.render(__value_of({{name}}), json, {{render_options.double_splat}})
+                  {% else %}
+                    {{render_with}}.render(__value_of({{name}}), json)
+                  {% end %}
                 end
               {% else %}
                 json.field %field, __value_of({{name}})

--- a/src/crinder/field.cr
+++ b/src/crinder/field.cr
@@ -22,7 +22,7 @@ module Crinder::Field
   # - **with**: a renderer for this field. This field will be filtered by `value` before passing to it. It is not necessary to be a subclass of `Crinder::Base`, but it must have the class method `render(object : T | Array(T), json : JSON::Builder)` where `T` is the original type of this field.
   # - **if**: a lambda, a class method or a constant to determine whether to show this field.
   # - **unless**: opposite of `if`. If both `if` and `unless` are provided, this field is only showed when `if` is *truthy* and `unless` is *falsey*.
-  macro field(decl, **options)
+  macro field(decl, **nargs)
     {%
       name = decl
       type = Object
@@ -35,12 +35,12 @@ module Crinder::Field
         nilable = type.types.any?(&.resolve.nilable?)
         type = type.types.reject(&.resolve.nilable?)[0]
       end
-      if type.is_a? Path
+      if type.is_a? Path || type.is_a? Generic
         type = type.resolve
         nilable = nilable || type == Nil
       end
       name = name.id
-      FIELDS[name] = options || {} of Nil => Nil
+      FIELDS[name] = nargs || {} of Nil => Nil
       FIELDS[name][:type] = type
       FIELDS[name][:nilable] = nilable
     %}


### PR DESCRIPTION
Example:

```crystal
record Article, title : String, content : String, date : Time

class TimeRenderer < Crinder::Base(Time)
  field year : Int
  field month : Int
  field day : Int
  field hour : Int, unless: date_only?
  field minute : Int, unless: date_only?
  field second : Int, unless: date_only?

  option date_only? : Bool = false
end

class ArticleRenderer < Crinder::Base(Article)
  field title : String
  field content : String
  field date, with: TimeRenderer, options: {date_only?: true}
end

article = Article.new(title: "Add render with options", content: "You can pass options to the nested renderer.", date: Time.local(2020, 4, 20))
ArticleRenderer.render(article) # => "{\"title\":\"Add render with options\",\"content\":\"You can pass options to the nested renderer.\",\"date\":{\"year\":2020,\"month\":4,\"day\":20}}"
```